### PR TITLE
Fix mural-client pagination options

### DIFF
--- a/packages/mural-client/src/index.ts
+++ b/packages/mural-client/src/index.ts
@@ -111,15 +111,25 @@ const isIntegration = (
 
 type Primitive = number | string | boolean | bigint;
 
-export type ResourceEndpoint<TResource, TParams = void, TOptions = null> = (
-  query: TParams,
-  options?: Partial<
-    (TOptions extends Sorted ? Sorted<TResource> : {}) &
-      (TOptions extends Paginated ? Paginated<TResource> : {}) &
-      (TOptions extends Integration ? Integration<TResource> : {}) &
-      TOptions
-  >,
-) => Promise<Envelope<TResource>>;
+type TResolvedOptions<TResource, TOptions> = Partial<
+  (TOptions extends Sorted ? Sorted<TResource> : {}) &
+    (TOptions extends Paginated ? Paginated<TResource> : {}) &
+    (TOptions extends Integration ? Integration<TResource> : {}) &
+    TOptions
+>;
+
+export type ResourceEndpoint<
+  TResource,
+  TParams = void,
+  TOptions = null,
+> = TParams extends void
+  ? (
+      options?: TResolvedOptions<TResource, TOptions>,
+    ) => Promise<Envelope<TResource>>
+  : (
+      query: TParams,
+      options?: TResolvedOptions<TResource, TOptions>,
+    ) => Promise<Envelope<TResource>>;
 
 const optionsParams = (
   options:


### PR DESCRIPTION
This PR fixes an issue with the new interface for the `mural-client`.

Most methods require a `query` parameter to specify what should be filtered from the public API, but some are context-free.

For instance, `getWorkspaces` is based on the current user's recently used murals, favorites and so on. Such an endpoint do not accept a query parameter, but can still be paginated and sorted.

This PR fixes an issue where a `void` parameter was present in the function declaration causing these endpoints not be usable with pagination.