### PR TITLE
Update the testing rig to use local packages

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -34,6 +34,7 @@ jobs:
       - run: npm ci
       - run: npx lerna bootstrap
       - run: npx lerna run build
+      - run: cd test && npm run test:react
       - run: npx lerna --no-verify-access publish from-git --yes
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/test/package.json
+++ b/test/package.json
@@ -13,10 +13,10 @@
     "@typescript-eslint/parser": "4.29.0"
   },
   "dependencies": {
-    "@muraldevkit/mural-integrations-mural-account-chooser": "v2.0.1-alpha.0",
-    "@muraldevkit/mural-integrations-mural-canvas": "v2.0.1-alpha.0",
-    "@muraldevkit/mural-integrations-mural-picker": "v2.0.1-alpha.0",
-    "@muraldevkit/mural-integrations-mural-client": "v2.0.1-alpha.0",
+    "@muraldevkit/mural-integrations-mural-account-chooser": "../packages/mural-account-chooser",
+    "@muraldevkit/mural-integrations-mural-canvas": "../packages/mural-canvas",
+    "@muraldevkit/mural-integrations-mural-picker": "../packages/mural-picker",
+    "@muraldevkit/mural-integrations-mural-client": "../packages/mural-client",
     "@testing-library/dom": "8.13.0",
     "@testing-library/react": "^11.2.0",
     "@testing-library/user-event": "^13.0.16",


### PR DESCRIPTION
I originally thought that `lerna` would automatically bump the required version of packages even for private packages, but it seems like it doesn't.

This PR fixes the build.