### PR TITLE
[ECO-191] Update MuralPicker to fetch all pages of rooms for a workspace

### DIFF
--- a/packages/mural-client/src/index.ts
+++ b/packages/mural-client/src/index.ts
@@ -123,9 +123,6 @@ const optionsParams = (
   if (isSorted(options)) {
     // @ts-ignore
     params.set('sortBy', options.sortBy.toString());
-
-    // @ts-ignore
-    delete options.sortBy;
   }
 
   if (isPaginated(options)) {
@@ -136,21 +133,18 @@ const optionsParams = (
     if (options.paginate.next) {
       params.set('next', options.paginate.next);
     }
-
-    // @ts-ignore
-    delete options.paginate;
   }
 
   if (isIntegration(options)) {
     if (options.integration)
       params.set('integration', options.integration.toString());
-
-    // @ts-ignore
-    delete options.integration;
   }
 
   // spread the rest as-is
   for (const [key, val] of Object.entries(options)) {
+    if (key === 'sortBy' || key === 'paginate' || key === 'integration') {
+      continue;
+    }
     params.set(key, val.toString());
   }
 

--- a/packages/mural-client/src/index.ts
+++ b/packages/mural-client/src/index.ts
@@ -41,13 +41,6 @@ export type ApiQueryFor<T extends keyof ApiClient> = ApiClient[T] extends (
   ? TQuery
   : never;
 
-export type PaginatedOptions = {
-  limit: number;
-  next: string;
-
-  sortBy?: string;
-};
-
 const DEFAULT_CONFIG = {
   muralHost: 'app.mural.co',
   integrationsHost: 'integrations.mural.co',
@@ -68,7 +61,7 @@ export const getApiError = async (error: Error): Promise<ApiError | null> => {
 
 export type Envelope<TResource> = {
   value: TResource;
-  next?: TResource extends any[] ? string | null : undefined;
+  next?: TResource extends any[] ? string : undefined;
 };
 
 type Sorted<TResource = null> = {
@@ -77,8 +70,8 @@ type Sorted<TResource = null> = {
 
 type Paginated<TResource = null> = {
   paginate: {
-    limit: number;
-    next?: string | null;
+    limit?: number;
+    next?: string;
   };
 } & Sorted<TResource>;
 
@@ -136,8 +129,13 @@ const optionsParams = (
   }
 
   if (isPaginated(options)) {
-    params.set('limit', options.paginate.limit.toString());
-    if (options.paginate.next) params.set('next', options.paginate.next);
+    if (options.paginate.limit) {
+      params.set('limit', options.paginate.limit.toString());
+    }
+
+    if (options.paginate.next) {
+      params.set('next', options.paginate.next);
+    }
 
     // @ts-ignore
     delete options.paginate;

--- a/packages/mural-picker/features/mural-picker.feature
+++ b/packages/mural-picker/features/mural-picker.feature
@@ -30,6 +30,17 @@ Feature: mural picker
     And I select "room3" in [room select]
     Then the [card title] at index 0 content is "${M4.title}"
 
+  Scenario: selecting a workspace loads multiple pages of rooms
+    # Force loading multiple pages by setting a small page size
+    Given mural api get rooms by workspace default limit is 2
+    # Add more rooms to workspace 2
+    And a room R10 with { "name": "room10", "workspaceId": "${W2.id}" }
+    And a room R11 with { "name": "room11", "workspaceId": "${W2.id}" }
+    And a room R12 with { "name": "room12", "workspaceId": "${W2.id}" }
+    And a room R13 with { "name": "room13", "workspaceId": "${W2.id}" }
+    When I select "workspace2" in [workspace select]
+    Then [room select] has 5 options
+
   Scenario: searching for a room in a workspace returns the room
     Given mural picker delay "DEBOUNCE_SEARCH" is 0ms
     When I select "workspace1" in [workspace select]

--- a/packages/mural-picker/features/mural-picker.feature
+++ b/packages/mural-picker/features/mural-picker.feature
@@ -32,7 +32,7 @@ Feature: mural picker
 
   Scenario: selecting a workspace loads multiple pages of rooms
     # Force loading multiple pages by setting a small page size
-    Given mural api get rooms by workspace default limit is 2
+    Given route /api/public/v1/workspaces/${W2.id}/rooms has page size 2
     # Add more rooms to workspace 2
     And a room R10 with { "name": "room10", "workspaceId": "${W2.id}" }
     And a room R11 with { "name": "room11", "workspaceId": "${W2.id}" }

--- a/packages/mural-picker/src/common/get-all.ts
+++ b/packages/mural-picker/src/common/get-all.ts
@@ -1,0 +1,31 @@
+import { ApiClient, Room } from '@muraldevkit/mural-integrations-mural-client';
+import cloneDeep from 'lodash/cloneDeep';
+
+type GetAllRoomsByWorkspace = (
+  apiClient: ApiClient,
+  ...params: Parameters<ApiClient['getRoomsByWorkspace']>
+) => Promise<Room[]>;
+
+export const getAllRoomsByWorkspace: GetAllRoomsByWorkspace = async (
+  apiClient,
+  query,
+  options,
+) => {
+  const rooms: Room[] = [];
+  let next: string | undefined;
+
+  const queryOptions = options ? cloneDeep(options) : {};
+  queryOptions.paginate = options?.paginate ?? {};
+
+  do {
+    // Get a page of rooms
+    queryOptions.paginate.next = next;
+    const result = await apiClient.getRoomsByWorkspace(query, queryOptions);
+    rooms.push(...result.value);
+
+    // Get the token to request the next page
+    next = result.next;
+  } while (next);
+
+  return rooms;
+};

--- a/packages/mural-picker/src/components/mural-create/index.tsx
+++ b/packages/mural-picker/src/components/mural-create/index.tsx
@@ -117,7 +117,7 @@ export default class MuralCreate extends React.Component<
           {
             paginate: {
               limit: LIMIT,
-              next: this.state.nextToken,
+              next: this.state.nextToken ?? undefined,
             },
           },
         );

--- a/packages/mural-picker/src/components/mural-picker/index.tsx
+++ b/packages/mural-picker/src/components/mural-picker/index.tsx
@@ -15,6 +15,7 @@ import {
 } from '@muraldevkit/mural-integrations-mural-client';
 import * as React from 'react';
 import { MURAL_PICKER_ERRORS } from '../../common/errors';
+import { getAllRoomsByWorkspace } from '../../common/get-all';
 import { getCommonTrackingProperties } from '../../common/tracking-properties';
 import CardList from '../card-list';
 import { CardSize } from '../card-list-item';
@@ -169,13 +170,11 @@ export default class MuralPicker extends React.Component<
       };
 
       const [uponRooms, uponMurals] = await Promise.all([
-        this.props.apiClient.getRoomsByWorkspace(q),
+        getAllRoomsByWorkspace(this.props.apiClient, q),
         this.props.apiClient.getMuralsByWorkspace(q),
       ]);
 
-      const rooms: Room[] = uponRooms.value.sort((a, b) =>
-        b.type.localeCompare(a.type),
-      );
+      const rooms = uponRooms.sort((a, b) => b.type.localeCompare(a.type));
 
       this.setState({
         workspace,

--- a/test/react/mocks/mural-api.ts
+++ b/test/react/mocks/mural-api.ts
@@ -6,23 +6,24 @@ import { FAKE_MURAL_HOST } from '../../utils';
 
 export const ROUTES = {
   // Public API
-  ME: `glob:*/api/public/v1/users/me`,
-  MURAL: `glob:*/api/public/v1/murals/*`,
-  MURALLY_OAUTH_SESSION: `glob:*/api/v0/authenticate/oauth2/session/*`,
-  MURALS: `glob:*/api/public/v1/murals*`,
-  ROOMS_MURALS: `glob:*/api/public/v1/rooms/*/murals*`,
-  WORKSPACES: `glob:*/api/public/v1/workspaces*`,
-  WORKSPACES_MURALS: `glob:*/api/public/v1/workspaces/*/murals*`,
-  WORKSPACES_ROOMS: `glob:*/api/public/v1/workspaces/*/rooms*`,
-  WORKSPACES_TEMPLATES: `glob:*/api/public/v1/workspaces/*/templates*`,
-  TEMPLATES: 'glob:*/api/public/v1/templates*',
-  TEMPLATES_MURALS: 'glob:*/api/public/v1/templates/*/murals*',
-  SEARCH_ROOMS: `glob:*/api/public/v1/search/*/rooms*`,
+  ME: 'express:/api/public/v1/users/me',
+  MURAL: 'express:/api/public/v1/murals',
+  MURALS: 'express:/api/public/v1/murals',
+  ROOMS_MURALS: 'express:/api/public/v1/rooms/:roomId/murals',
+  WORKSPACES: 'express:/api/public/v1/workspaces',
+  WORKSPACES_MURALS: 'express:/api/public/v1/workspaces/:workspaceId/murals',
+  WORKSPACES_ROOMS: 'express:/api/public/v1/workspaces/:workspaceId/rooms',
+  WORKSPACES_TEMPLATES:
+    'express:/api/public/v1/workspaces/:workspaceId/templates',
+  TEMPLATES: 'experss:/api/public/v1/templates',
+  TEMPLATES_MURALS: 'express:/api/public/v1/templates/:templateId/murals',
+  SEARCH_ROOMS: 'express:/api/public/v1/search/:workspaceId/rooms',
 
   // Internal API
   REALM: `glob:*/api/v0/user/realm`,
   MURAL_INTERNAL: `glob:*/api/murals/*/*`,
   MURAL_VISITOR: 'glob:*/api/v0/visitor/*.*',
+  MURALLY_OAUTH_SESSION: `glob:*/api/v0/authenticate/oauth2/session/*`,
   GLOBAL_TEMPLATES: 'glob:*/api/v0/templates/globals*',
 };
 

--- a/test/react/step-definitions/given/misc.ts
+++ b/test/react/step-definitions/given/misc.ts
@@ -2,12 +2,16 @@ import { SetupFnArgs } from 'pickled-cucumber/types';
 import { setSession } from '@muraldevkit/mural-integrations-mural-client';
 import { DELAYS as MURAL_PICKER_DELAY } from '@muraldevkit/mural-integrations-mural-picker';
 import { dummyToken, get, set } from '../../../utils';
-import { MURAL_API_GET_ROOMS_BY_WORKSPACE_DEFAULT_LIMIT_KEY } from '../../mocks/mural-api';
+import {
+  MURAL_API_PAGE_SIZE_BY_ROUTE_KEY,
+  PageSizeByRouteMap,
+} from '../../mocks/mural-api';
 
 export const USER_PRINCIPAL_NAME = '$user-principal';
 
 export default function registerGiven({
   Given,
+  getCtx,
   setCtx,
   onTearDown,
 }: SetupFnArgs) {
@@ -61,9 +65,16 @@ export default function registerGiven({
 
   // USAGE:
   //
-  // Given mural api get rooms by workspace default limit is 10
-  Given('mural api get rooms by workspace default limit is {int}', limit => {
-    setCtx(MURAL_API_GET_ROOMS_BY_WORKSPACE_DEFAULT_LIMIT_KEY, limit);
+  // Given route /api/public/v1/workspaces/test1234/rooms has page size 2
+  // Given route /api/public/v1/workspaces/${WORKSPACE.id}/rooms has page size 10
+  Given('route {word} has page size {int}', (route, limitStr) => {
+    const pageSizes =
+      getCtx<PageSizeByRouteMap>(MURAL_API_PAGE_SIZE_BY_ROUTE_KEY) ?? new Map();
+
+    const limit = parseInt(limitStr, 10);
+    pageSizes.set(route, limit);
+
+    setCtx(MURAL_API_PAGE_SIZE_BY_ROUTE_KEY, pageSizes);
   });
 
   // USAGE:

--- a/test/react/step-definitions/given/misc.ts
+++ b/test/react/step-definitions/given/misc.ts
@@ -2,6 +2,7 @@ import { SetupFnArgs } from 'pickled-cucumber/types';
 import { setSession } from '@muraldevkit/mural-integrations-mural-client';
 import { DELAYS as MURAL_PICKER_DELAY } from '@muraldevkit/mural-integrations-mural-picker';
 import { dummyToken, get, set } from '../../../utils';
+import { MURAL_API_GET_ROOMS_BY_WORKSPACE_DEFAULT_LIMIT_KEY } from '../../mocks/mural-api';
 
 export const USER_PRINCIPAL_NAME = '$user-principal';
 
@@ -56,6 +57,13 @@ export default function registerGiven({
     onTearDown(() => {
       set(MURAL_PICKER_DELAY, delayName, prev);
     });
+  });
+
+  // USAGE:
+  //
+  // Given mural api get rooms by workspace default limit is 10
+  Given('mural api get rooms by workspace default limit is {int}', limit => {
+    setCtx(MURAL_API_GET_ROOMS_BY_WORKSPACE_DEFAULT_LIMIT_KEY, limit);
   });
 
   // USAGE:

--- a/test/react/step-definitions/then/dom.ts
+++ b/test/react/step-definitions/then/dom.ts
@@ -1,6 +1,6 @@
 import { SetupFnArgs } from 'pickled-cucumber/types';
 import { fail } from 'assert';
-import { fireEvent } from '@testing-library/react';
+import { fireEvent, screen, within } from '@testing-library/react';
 import { getElement, queryElement, waitForElementWithText } from '../../pages';
 import { elementAt } from '../utils';
 
@@ -123,7 +123,7 @@ export default function registerThen({ Then, compare }: SetupFnArgs) {
   Then('{descriptor} has {int} options?', async (descriptor, choiceCount) => {
     const element = await getElement(descriptor);
 
-    const selectControlElement = element.querySelector('.Select-control');
+    const selectControlElement = await within(element).findByRole('combobox');
     if (!selectControlElement) {
       fail(`${descriptor} has no select element`);
     }
@@ -131,15 +131,12 @@ export default function registerThen({ Then, compare }: SetupFnArgs) {
     // Trigger the dropdown - the dropdown need to be opened for the options to be rendered
     fireEvent.keyDown(selectControlElement, { key: 'ArrowDown', keyCode: 40 });
 
-    const selectMenuElement = element.querySelector('.Select-menu');
-    if (!selectMenuElement) {
-      fail(`${descriptor} has no select menu element`);
-    }
+    const selectOptions = screen.queryAllByRole('option');
 
     // Close the dropdown
     fireEvent.keyDown(selectControlElement, { key: 'Escape', keyCode: 27 });
 
-    compare('is', selectMenuElement.childElementCount, choiceCount);
+    compare('is', selectOptions.length, choiceCount);
   });
 
   // USAGE:


### PR DESCRIPTION
JIRA: [ECO-191](https://mural.atlassian.net/browse/ECO-191)

Before this change, the `MuralPicker` component fetched only the first page of rooms for a workspace. After this change, the component fetches all the pages of rooms.