### PR TITLE
[MI-716] throw InvalidSessionError when refresh token fails

### DIFF
--- a/packages/mural-client/src/fetch.ts
+++ b/packages/mural-client/src/fetch.ts
@@ -88,7 +88,7 @@ async function verifyTokensExpiration() {
     if (isTokenExpired(session.refreshToken)) {
       fetchConfig.sessionStore.delete();
     } else if (isTokenExpired(session.accessToken)) {
-      await fetchConfig.refreshTokenFn({ store: true });
+      await refreshToken();
     }
   }
 }
@@ -101,6 +101,20 @@ function isTokenExpired(token: string) {
     }
   }
   return true;
+}
+
+async function refreshToken() {
+  try {
+    await fetchConfig.refreshTokenFn({ store: true });
+  } catch (e) {
+    if (
+      e instanceof FetchError &&
+      e.response.status >= 400 &&
+      e.response.status < 500
+    )
+      throw InvalidSessionError.fromError(e);
+    throw e;
+  }
 }
 
 export class FetchError extends Error {
@@ -149,7 +163,7 @@ function catchAuthenticationError(input: RequestInfo, init: RequestInit = {}) {
       session &&
       session.refreshToken
     ) {
-      await fetchConfig.refreshTokenFn({ store: true });
+      await refreshToken();
       // For api retry we should use the newly refreshed token and not the original one
       return authenticatedFetch(input, init);
     }
@@ -226,38 +240,40 @@ export interface AuthorizeHandlerOptions {
  *
  * @returns Authorization URL
  */
-export const authorizeHandler = (config: TokenHandlerConfig) => async (
-  redirectUri?: string,
-  opts: AuthorizeHandlerOptions = { storeState: false },
-): Promise<string> => {
-  const state = generateState();
+export const authorizeHandler =
+  (config: TokenHandlerConfig) =>
+  async (
+    redirectUri?: string,
+    opts: AuthorizeHandlerOptions = { storeState: false },
+  ): Promise<string> => {
+    const state = generateState();
 
-  const params = qs.stringify(
-    {
-      state,
-      redirectUri,
-      auto: opts.authorizeParams?.auto
-        ? encodeAutoParam(opts.authorizeParams.auto)
-        : undefined,
-      signup: opts.authorizeParams?.signup || undefined,
-      reauthenticate: opts.authorizeParams?.reauthenticate || undefined,
-      ...opts.authorizeParams?.forward,
-    },
-    { encode: true },
-  );
+    const params = qs.stringify(
+      {
+        state,
+        redirectUri,
+        auto: opts.authorizeParams?.auto
+          ? encodeAutoParam(opts.authorizeParams.auto)
+          : undefined,
+        signup: opts.authorizeParams?.signup || undefined,
+        reauthenticate: opts.authorizeParams?.reauthenticate || undefined,
+        ...opts.authorizeParams?.forward,
+      },
+      { encode: true },
+    );
 
-  const url = `${config.authorizeUri}?${params}`;
+    const url = `${config.authorizeUri}?${params}`;
 
-  const authorizeUrl = await fetch(url, { method: 'GET' })
-    .then(checkStatus)
-    .then(res => res.text());
+    const authorizeUrl = await fetch(url, { method: 'GET' })
+      .then(checkStatus)
+      .then(res => res.text());
 
-  if (opts.storeState) {
-    storeState(state);
-  }
+    if (opts.storeState) {
+      storeState(state);
+    }
 
-  return authorizeUrl;
-};
+    return authorizeUrl;
+  };
 
 /**
  * Exchange the `authorization_code` via the configured Auth service.
@@ -273,25 +289,27 @@ export const authorizeHandler = (config: TokenHandlerConfig) => async (
  *
  * @returns The token pair issued from the MURAL OAuth service
  */
-export const requestTokenHandler = (config: TokenHandlerConfig) => async (
-  code: string,
-  state: string,
-  opts = { store: false },
-): Promise<Session> => {
-  // validate that the state hasn't been tampered
-  if (!validateState(state)) throw new Error('INVALID_STATE');
+export const requestTokenHandler =
+  (config: TokenHandlerConfig) =>
+  async (
+    code: string,
+    state: string,
+    opts = { store: false },
+  ): Promise<Session> => {
+    // validate that the state hasn't been tampered
+    if (!validateState(state)) throw new Error('INVALID_STATE');
 
-  const url = `${config.requestTokenUri}?code=${code}`;
-  const session = await fetch(url, { method: 'GET' })
-    .then(checkStatus)
-    .then(res => res.json());
+    const url = `${config.requestTokenUri}?code=${code}`;
+    const session = await fetch(url, { method: 'GET' })
+      .then(checkStatus)
+      .then(res => res.json());
 
-  if (opts.store) {
-    fetchConfig.sessionStore.set(session);
-  }
+    if (opts.store) {
+      fetchConfig.sessionStore.set(session);
+    }
 
-  return session;
-};
+    return session;
+  };
 
 /**
  * Exchange the MURAL `refreshToken` via the configured Auth service.
@@ -301,31 +319,31 @@ export const requestTokenHandler = (config: TokenHandlerConfig) => async (
  *
  * @returns The token pair issued from the MURAL OAuth service
  */
-export const refreshTokenHandler = (config: TokenHandlerConfig) => async (
-  opts = { store: false },
-): Promise<Session> => {
-  const staleSession = fetchConfig.sessionStore.get();
-  const options = {
-    method: 'POST',
-    headers: {
-      Accept: 'application/json',
-      'Content-Type': 'application/json; charset=utf-8',
-    },
-    body: JSON.stringify({
-      refreshToken: staleSession && staleSession.refreshToken,
-    }),
+export const refreshTokenHandler =
+  (config: TokenHandlerConfig) =>
+  async (opts = { store: false }): Promise<Session> => {
+    const staleSession = fetchConfig.sessionStore.get();
+    const options = {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json; charset=utf-8',
+      },
+      body: JSON.stringify({
+        refreshToken: staleSession && staleSession.refreshToken,
+      }),
+    };
+
+    const freshSession: Session = await fetch(config.refreshTokenUri, options)
+      .then(checkStatus)
+      .then(res => res.json());
+
+    if (opts.store) {
+      fetchConfig.sessionStore.set(freshSession);
+    }
+
+    return freshSession;
   };
-
-  const freshSession: Session = await fetch(config.refreshTokenUri, options)
-    .then(checkStatus)
-    .then(res => res.json());
-
-  if (opts.store) {
-    fetchConfig.sessionStore.set(freshSession);
-  }
-
-  return freshSession;
-};
 
 // This is a shortcut as this file as multiple dependencies
 // we'll ensure we require the call to `setup` or anyways


### PR DESCRIPTION
# Description

We were doing nothing special in case the `refreshToken` call fails.
In that situation, the user is stuck with an invalid session.
So this PR is throwing the `InvalidSessionError` when `refreshToken` call fails.

In most of our integration, the `InvalidSessionError` is handled to delete the current user session and request a new one.

# Jira

https://mural.atlassian.net/browse/MI-716