### PR TITLE
[ECO-249] mural-client: Add createContentSession endpoint

### DIFF
--- a/packages/mural-client/src/index.ts
+++ b/packages/mural-client/src/index.ts
@@ -1,6 +1,7 @@
 import { authenticated, getFetchConfig, FetchError } from './fetch';
 import {
   Mural,
+  MuralContentSession,
   Room,
   StickyNote,
   Tag,
@@ -179,6 +180,12 @@ export interface ApiClient {
       };
     }
   >;
+  createContentSession: ResourceEndpoint<
+    MuralContentSession,
+    {
+      muralId: string;
+    }
+  >;
   createImage: ResourceEndpoint<
     Image,
     {
@@ -343,6 +350,15 @@ export default (fetchFn: FetchFunction, config: ClientConfig): ApiClient => {
     createAsset: async ({ muralId, payload }) => {
       const response = await fetchFn(api(`murals/${muralId}/assets`), {
         body: JSON.stringify(payload),
+        headers: { 'content-type': 'application/json' },
+        method: 'POST',
+      });
+
+      return response.json();
+    },
+    // Documented internally
+    createContentSession: async ({ muralId }) => {
+      const response = await fetchFn(api(`murals/${muralId}/content-session`), {
         headers: { 'content-type': 'application/json' },
         method: 'POST',
       });

--- a/packages/mural-client/src/types.ts
+++ b/packages/mural-client/src/types.ts
@@ -57,6 +57,18 @@ export type Mural = {
   _canvasLink: string;
 };
 
+export type MuralContentSession = {
+  token: string;
+  workspaceId: string;
+  zone: {
+    endpoints: {
+      api: string;
+      realtime: string;
+    };
+    id: string;
+  };
+};
+
 export type Template = {
   description: string;
   id: string;


### PR DESCRIPTION
JIRA: [ECO-249](https://mural.atlassian.net/browse/ECO-249)

Add the `createContentSession` endpoint to mural-client. The endpoint response includes a content token that's valid only for the specified mural. Requests that use this token should target the server returned in `zone.endpoints.api`.