### PR TITLE
[ECO-293] Update pickers to fetch all pages of workspaces

### DIFF
--- a/packages/mural-client/src/index.ts
+++ b/packages/mural-client/src/index.ts
@@ -519,8 +519,9 @@ export default (fetchFn: FetchFunction, config: ClientConfig): ApiClient => {
       return response.json();
     },
     // https://developers.mural.co/public/reference/getworkspaces
-    getWorkspaces: async () => {
-      const response = await fetchFn(api(`workspaces`), {
+    getWorkspaces: async options => {
+      const params = optionsParams(options);
+      const response = await fetchFn(api(`workspaces?${params}`), {
         method: 'GET',
       });
       return await response.json();

--- a/packages/mural-picker/features/mural-picker.feature
+++ b/packages/mural-picker/features/mural-picker.feature
@@ -50,3 +50,14 @@ Feature: mural picker
     And typing "room2" on the [input room select]
     And I select "room2" in [room select]
     Then the [card title] at index 0 content is "${M3.title}"
+
+  Scenario: loads multiple pages of workspaces
+    # Force loading multiple pages by setting a small page size
+    Given route /api/public/v1/workspaces has page size 2
+    # Add more workspaces
+    And a workspace W3 with { "name": "workspace3" }
+    And a workspace W4 with { "name": "workspace4" }
+    And a workspace W5 with { "name": "workspace5" }
+    # Reopen the mural picker to reload the workspaces
+    And the page rerenders
+    Then [workspace select] has 5 options

--- a/packages/mural-picker/features/room-picker.feature
+++ b/packages/mural-picker/features/room-picker.feature
@@ -1,0 +1,24 @@
+Feature: room picker
+
+  Background:
+    # Workspace 1
+    Given a workspace W1 with { "name": "workspace1" }
+    And a room R1 with { "name": "room1", "workspaceId": "${W1.id}" }
+    And a room R2 with { "name": "room2", "workspaceId": "${W1.id}" }
+    # Workspace 2
+    And a workspace W2 with { "name": "workspace2" }
+    And a room R3 with { "name": "room3", "workspaceId": "${W2.id}" }
+    And a room R4 with { "name": "room4", "workspaceId": "${W2.id}" }
+    # Open room picker
+    And I visit the "room picker" route
+    And the route has finished loading
+
+  Scenario: the room picker is shown
+    Then [room picker] is shown
+
+  Scenario: select a workspace and a room
+    When I select "workspace2" in [workspace select]
+    And I select "room3" in [room select]
+    And I click on [room select button]
+    Then the last selected workspace is ${W2}
+    And the last selected room is ${R3}

--- a/packages/mural-picker/features/room-picker.feature
+++ b/packages/mural-picker/features/room-picker.feature
@@ -22,3 +22,14 @@ Feature: room picker
     And I click on [room select button]
     Then the last selected workspace is ${W2}
     And the last selected room is ${R3}
+
+  Scenario: loads multiple pages of workspaces
+    # Force loading multiple pages by setting a small page size
+    Given route /api/public/v1/workspaces has page size 2
+    # Add more workspaces
+    And a workspace W3 with { "name": "workspace3" }
+    And a workspace W4 with { "name": "workspace4" }
+    And a workspace W5 with { "name": "workspace5" }
+    # Reopen the room picker to reload the workspaces
+    And the page rerenders
+    Then [workspace select] has 5 options

--- a/packages/mural-picker/features/workspace-picker.feature
+++ b/packages/mural-picker/features/workspace-picker.feature
@@ -20,3 +20,14 @@ Feature: workspace picker
     When I select "workspace2" in [workspace select]
     And I click on [workspace select button]
     Then the last selected workspace is ${W2}
+
+  Scenario: loads multiple pages of workspaces
+    # Force loading multiple pages by setting a small page size
+    Given route /api/public/v1/workspaces has page size 2
+    # Add more workspaces
+    And a workspace W3 with { "name": "workspace3" }
+    And a workspace W4 with { "name": "workspace4" }
+    And a workspace W5 with { "name": "workspace5" }
+    # Reopen the workspace picker to reload the workspaces
+    And the page rerenders
+    Then [workspace select] has 5 options

--- a/packages/mural-picker/features/workspace-picker.feature
+++ b/packages/mural-picker/features/workspace-picker.feature
@@ -1,0 +1,22 @@
+Feature: workspace picker
+
+  Background:
+    # Workspace 1
+    Given a workspace W1 with { "name": "workspace1" }
+    # Workspace 2
+    And a workspace W2 with { "name": "workspace2" }
+    # Open workspace picker
+    And I visit the "workspace picker" route
+    And the route has finished loading
+
+  Scenario: the workspace picker is shown
+    Then [workspace picker] is shown
+
+  Scenario: the first workspace is selected by default
+    When I click on [workspace select button]
+    Then the last selected workspace is ${W1}
+
+  Scenario: change the selected workspace
+    When I select "workspace2" in [workspace select]
+    And I click on [workspace select button]
+    Then the last selected workspace is ${W2}

--- a/packages/mural-picker/src/common/get-all.ts
+++ b/packages/mural-picker/src/common/get-all.ts
@@ -1,10 +1,19 @@
-import { ApiClient, Room } from '@muraldevkit/mural-integrations-mural-client';
+import {
+  ApiClient,
+  Room,
+  Workspace,
+} from '@muraldevkit/mural-integrations-mural-client';
 import cloneDeep from 'lodash/cloneDeep';
 
 type GetAllRoomsByWorkspace = (
   apiClient: ApiClient,
   ...params: Parameters<ApiClient['getRoomsByWorkspace']>
 ) => Promise<Room[]>;
+
+type GetAllWorkspaces = (
+  apiClient: ApiClient,
+  ...params: Parameters<ApiClient['getWorkspaces']>
+) => Promise<Workspace[]>;
 
 export const getAllRoomsByWorkspace: GetAllRoomsByWorkspace = async (
   apiClient,
@@ -28,4 +37,27 @@ export const getAllRoomsByWorkspace: GetAllRoomsByWorkspace = async (
   } while (next);
 
   return rooms;
+};
+
+export const getAllWorkspaces: GetAllWorkspaces = async (
+  apiClient,
+  options,
+) => {
+  const workspaces: Workspace[] = [];
+  let next: string | undefined;
+
+  const queryOptions = options ? cloneDeep(options) : {};
+  queryOptions.paginate = options?.paginate ?? {};
+
+  do {
+    // Get a page of workspaces
+    queryOptions.paginate.next = next;
+    const result = await apiClient.getWorkspaces(queryOptions);
+    workspaces.push(...result.value);
+
+    // Get the token to request the next page
+    next = result.next;
+  } while (next);
+
+  return workspaces;
 };

--- a/packages/mural-picker/src/components/mural-picker/index.tsx
+++ b/packages/mural-picker/src/components/mural-picker/index.tsx
@@ -15,7 +15,7 @@ import {
 } from '@muraldevkit/mural-integrations-mural-client';
 import * as React from 'react';
 import { MURAL_PICKER_ERRORS } from '../../common/errors';
-import { getAllRoomsByWorkspace } from '../../common/get-all';
+import { getAllRoomsByWorkspace, getAllWorkspaces } from '../../common/get-all';
 import { getCommonTrackingProperties } from '../../common/tracking-properties';
 import CardList from '../card-list';
 import { CardSize } from '../card-list-item';
@@ -137,19 +137,17 @@ export default class MuralPicker extends React.Component<
     try {
       this.transition(Segue.LOADING);
 
-      const eWorkspaces = await this.props.apiClient.getWorkspaces();
-      const currentUser = await this.props.apiClient.getCurrentUser();
+      const [workspaces, currentUser] = await Promise.all([
+        getAllWorkspaces(this.props.apiClient),
+        this.props.apiClient.getCurrentUser(),
+      ]);
       const lastActiveWorkspaceId = currentUser.value.lastActiveWorkspace;
 
-      if (eWorkspaces.value.length) {
+      if (workspaces.length) {
         const workspace =
-          eWorkspaces.value.find(w => w.id === lastActiveWorkspaceId) ||
-          eWorkspaces.value[0];
+          workspaces.find(w => w.id === lastActiveWorkspaceId) || workspaces[0];
 
-        this.setState(
-          { workspaces: eWorkspaces.value, workspace },
-          this.trackDisplay,
-        );
+        this.setState({ workspaces, workspace }, this.trackDisplay);
 
         await this.handleWorkspaceSelect(workspace);
       }

--- a/packages/mural-picker/src/components/room-picker/index.tsx
+++ b/packages/mural-picker/src/components/room-picker/index.tsx
@@ -14,6 +14,7 @@ import {
 import cx from 'classnames';
 import * as React from 'react';
 import { MURAL_PICKER_ERRORS } from '../../common/errors';
+import { getAllWorkspaces } from '../../common/get-all';
 import { ReactSlot } from '../../common/react';
 import { PrimaryButton } from '../common';
 import RoomSelect from '../room-select';
@@ -87,9 +88,9 @@ export default class RoomPicker extends React.Component<PropTypes> {
   loadWorkspaces = async () => {
     this.setState({ isLoading: true });
     try {
-      const eWorkspaces = await this.props.apiClient.getWorkspaces();
-      if (eWorkspaces.value.length) {
-        this.setState({ workspaces: eWorkspaces.value, isLoading: false });
+      const workspaces = await getAllWorkspaces(this.props.apiClient);
+      if (workspaces.length) {
+        this.setState({ workspaces, isLoading: false });
       }
     } catch (e: any) {
       this.handleError(e, 'Error retrieving workspaces.');

--- a/packages/mural-picker/src/components/room-picker/index.tsx
+++ b/packages/mural-picker/src/components/room-picker/index.tsx
@@ -190,7 +190,10 @@ export default class RoomPicker extends React.Component<PropTypes> {
 
     return (
       <ThemeProvider theme={muiTheme}>
-        <div className={cx('room-picker-body', muiTheme?.palette?.type)}>
+        <div
+          className={cx('room-picker-body', muiTheme?.palette?.type)}
+          data-qa="room-picker"
+        >
           <div className="select-row">
             <slots.WorkspaceSelect.Self
               workspace={this.state.workspace}

--- a/packages/mural-picker/src/components/workspace-picker/index.tsx
+++ b/packages/mural-picker/src/components/workspace-picker/index.tsx
@@ -116,7 +116,10 @@ export default class WorkspacePicker extends React.Component<WorkspacePickerProp
 
     return (
       <ThemeProvider theme={muiTheme}>
-        <div className={cx('workspace-picker-body', muiTheme?.palette?.type)}>
+        <div
+          className={cx('workspace-picker-body', muiTheme?.palette?.type)}
+          data-qa="workspace-picker"
+        >
           <div className="select-row">
             <WorkspaceSelect
               workspace={this.state.workspace}

--- a/packages/mural-picker/src/components/workspace-picker/index.tsx
+++ b/packages/mural-picker/src/components/workspace-picker/index.tsx
@@ -10,6 +10,7 @@ import {
   Workspace,
 } from '@muraldevkit/mural-integrations-mural-client';
 import * as React from 'react';
+import { getAllWorkspaces } from '../../common/get-all';
 import { PrimaryButton } from '../common';
 import createTheme, { Preset } from '../theme';
 import WorkspaceSelect from '../workspace-select';
@@ -59,15 +60,15 @@ export default class WorkspacePicker extends React.Component<WorkspacePickerProp
     this.setState({ isLoading: true });
 
     try {
-      const eWorkspaces = await this.props.apiClient.getWorkspaces();
-      if (eWorkspaces.value.length) {
+      const workspaces = await getAllWorkspaces(this.props.apiClient);
+      if (workspaces.length) {
         const workspace =
-          eWorkspaces.value.find(w => w.id === this.props.initialWorkspaceId) ||
-          eWorkspaces.value[0];
+          workspaces.find(w => w.id === this.props.initialWorkspaceId) ||
+          workspaces[0];
 
         this.setState({
           workspace,
-          workspaces: eWorkspaces.value,
+          workspaces,
           isLoading: false,
         });
       }

--- a/test/react/pages/index.ts
+++ b/test/react/pages/index.ts
@@ -15,6 +15,8 @@ import muralView from './mural-view';
 import oAuthSessionActivation from './oauth-session-activation';
 import accountChooser from './account-chooser';
 import homePage from './homepage';
+import roomPicker from './room-picker';
+import workspacePicker from './workspace-picker';
 
 const CURRENT_PAGE_NAME = '$currentPageName';
 export const CURRENT_PAGE = '$currentPage';
@@ -28,6 +30,8 @@ const PAGES: Record<PageName, Page> = {
   'mural view': muralView,
   'oauth session activation': oAuthSessionActivation,
   'account chooser': accountChooser,
+  'room picker': roomPicker,
+  'workspace picker': workspacePicker,
 };
 
 const getErrorMessage = (header: string, body?: string) => `

--- a/test/react/pages/room-picker.tsx
+++ b/test/react/pages/room-picker.tsx
@@ -1,0 +1,31 @@
+import { Room, Workspace } from '@muraldevkit/mural-integrations-mural-client';
+import { RoomPicker } from '@muraldevkit/mural-integrations-mural-picker';
+import { setCtxItem } from 'pickled-cucumber/context';
+import * as React from 'react';
+import { apiClient } from '../helpers/apiClient';
+import { Page } from './types';
+
+const roomPicker: Page = {
+  element: () => {
+    const onSelect = (room: Room | null, workspace: Workspace | null) => {
+      setCtxItem('$lastSelectedRoom', room);
+      setCtxItem('$lastSelectedWorkspace', workspace);
+    };
+
+    return (
+      <RoomPicker
+        apiClient={apiClient}
+        onSelect={onSelect}
+        onError={(_: Error, __: string) => {}}
+      />
+    );
+  },
+  items: {
+    'room picker': 'room-picker',
+    'room select': 'room-select',
+    'room select button': 'room-picker-button',
+    'workspace select': 'workspace-select',
+  },
+};
+
+export default roomPicker;

--- a/test/react/pages/types.ts
+++ b/test/react/pages/types.ts
@@ -4,7 +4,9 @@ export type PageName =
   | 'home page'
   | 'mural picker'
   | 'mural view'
-  | 'oauth session activation';
+  | 'oauth session activation'
+  | 'room picker'
+  | 'workspace picker';
 
 // A `Page` is a representation of the DOM element we will render for a given
 // route with some useful metadata.

--- a/test/react/pages/workspace-picker.tsx
+++ b/test/react/pages/workspace-picker.tsx
@@ -1,0 +1,29 @@
+import { Workspace } from '@muraldevkit/mural-integrations-mural-client';
+import { WorkspacePicker } from '@muraldevkit/mural-integrations-mural-picker';
+import { setCtxItem } from 'pickled-cucumber/context';
+import * as React from 'react';
+import { apiClient } from '../helpers/apiClient';
+import { Page } from './types';
+
+const workspacePicker: Page = {
+  element: () => {
+    const onSelect = (workspace: Workspace | null) => {
+      setCtxItem('$lastSelectedWorkspace', workspace);
+    };
+
+    return (
+      <WorkspacePicker
+        apiClient={apiClient}
+        onSelect={onSelect}
+        onError={(_: Error, __: string) => {}}
+      />
+    );
+  },
+  items: {
+    'workspace picker': 'workspace-picker',
+    'workspace select': 'workspace-select',
+    'workspace select button': 'workspace-picker-button',
+  },
+};
+
+export default workspacePicker;

--- a/test/react/step-definitions/then/index.ts
+++ b/test/react/step-definitions/then/index.ts
@@ -3,9 +3,11 @@ import { SetupFnArgs } from 'pickled-cucumber/types';
 import dom from './dom';
 import misc from './misc';
 import network from './network';
+import pickers from './pickers';
 
 export default function registerThen(args: SetupFnArgs) {
   dom(args);
   misc(args);
   network(args);
+  pickers(args);
 }

--- a/test/react/step-definitions/then/pickers.ts
+++ b/test/react/step-definitions/then/pickers.ts
@@ -1,0 +1,20 @@
+import capitalize from 'lodash/capitalize';
+import { SetupFnArgs } from 'pickled-cucumber/types';
+
+export default function registerThen({ Then, compare, getCtx }: SetupFnArgs) {
+  // USAGE:
+  //
+  // Then the last selected room is ${R}
+  // Then the last selected workspace is ${W}
+  Then(
+    'the last selected (room|workspace) {op}',
+    (entityName, op, payload) => {
+      const key = `$lastSelected${capitalize(entityName)}`;
+      const entity = getCtx(key);
+      compare(op, entity, payload);
+    },
+    {
+      inline: true,
+    },
+  );
+}


### PR DESCRIPTION
JIRA: [ECO-293](https://mural.atlassian.net/browse/ECO-293)

Before this change, the `MuralPicker`, `RoomPicker`, and `WorkspacePicker` components fetched only the first page of workspaces. After this change, the components fetch all the pages of workspaces.