### PR TITLE
[ECO-521] Update several Mural properties to be optional

### DIFF
--- a/packages/mural-client/src/types.ts
+++ b/packages/mural-client/src/types.ts
@@ -26,28 +26,28 @@ export type Mural = {
   /** @deprecated
    * This field will require the new DR content API in the future
    */
-  createdBy: {
+  createdBy?: {
     firstName: string;
     lastName: string;
     email: string;
     id: string;
   };
   createdOn: number;
-  favorite: boolean;
+  favorite?: boolean;
   title: string;
-  thumbnailUrl: string;
+  thumbnailUrl?: string;
   roomId: number;
   /** @deprecated
    * This field will require the new DR content API in the future
    */
-  updatedBy: {
+  updatedBy?: {
     firstName: string;
     lastName: string;
     email: string;
     id: string;
   };
   updatedOn: number;
-  visitorsSettings: {
+  visitorsSettings?: {
     link: string;
     visitors: string;
     workspaceMembers: string;

--- a/packages/mural-picker/src/components/card-list-item/styles.scss
+++ b/packages/mural-picker/src/components/card-list-item/styles.scss
@@ -53,6 +53,7 @@
     }
 
     display: flex;
+    height: 32px;
     margin-top: 0.675em;
 
     .card-details {
@@ -69,7 +70,6 @@
 
     .card-avatar {
       margin-right: 0.375em;
-      height: 32px;
       width: 32px;
 
       background: rgba(35, 186, 150, 0.08);

--- a/packages/mural-picker/src/components/card-list/index.tsx
+++ b/packages/mural-picker/src/components/card-list/index.tsx
@@ -7,13 +7,17 @@ import { CardListSection } from './card-list-section';
 import './styles.scss';
 
 export const muralCardItemSource = (mural: Mural) => {
-  const { firstName, lastName } = mural.createdBy;
+  const firstName = mural.createdBy?.firstName;
+  const lastName = mural.createdBy?.lastName;
+
+  const firstInitial = firstName ? firstName[0] : '';
+  const lastInitial = lastName ? lastName[0] : '';
 
   return {
     title: mural.title || 'Untitled mural',
     details: dateMarkers(mural),
-    thumbnailUrl: mural.thumbnailUrl,
-    initials: (firstName[0] || '') + (lastName[0] || ''),
+    thumbnailUrl: mural.thumbnailUrl ?? '',
+    initials: firstInitial + lastInitial,
   };
 };
 

--- a/storybook/stories/mural-picker.stories.tsx
+++ b/storybook/stories/mural-picker.stories.tsx
@@ -61,6 +61,7 @@ const apiClient: ApiClient = {
     secure: true,
   } as ClientConfig,
   abort: () => {},
+  clone: () => apiClient,
   track: () => {},
   getCurrentUser: () =>
     Promise.resolve({ value: { email: '', id: 'xxx' } as User }),

--- a/test/react/entities/schema.ts
+++ b/test/react/entities/schema.ts
@@ -18,29 +18,35 @@ export const validateTypeFactory =
 
 export const MuralSchema = z.object({
   id: z.string(),
-  createdBy: z.object({
-    firstName: z.string(),
-    lastName: z.string(),
-    email: z.string(),
-    id: z.string(),
-  }),
+  createdBy: z
+    .object({
+      firstName: z.string(),
+      lastName: z.string(),
+      email: z.string(),
+      id: z.string(),
+    })
+    .optional(),
   createdOn: z.number().int(),
-  favorite: z.boolean(),
+  favorite: z.boolean().optional(),
   title: z.string(),
-  thumbnailUrl: z.string(),
+  thumbnailUrl: z.string().optional(),
   roomId: z.number().int(),
-  updatedBy: z.object({
-    firstName: z.string(),
-    lastName: z.string(),
-    email: z.string(),
-    id: z.string(),
-  }),
+  updatedBy: z
+    .object({
+      firstName: z.string(),
+      lastName: z.string(),
+      email: z.string(),
+      id: z.string(),
+    })
+    .optional(),
   updatedOn: z.number().int(),
-  visitorsSettings: z.object({
-    link: z.string(),
-    visitors: z.string(),
-    workspaceMembers: z.string(),
-  }),
+  visitorsSettings: z
+    .object({
+      link: z.string(),
+      visitors: z.string(),
+      workspaceMembers: z.string(),
+    })
+    .optional(),
   workspaceId: z.string(),
   _canvasLink: z.string(),
 });


### PR DESCRIPTION
JIRA: [ECO-521](https://mural.atlassian.net/browse/ECO-521)

- Update mural-client's `Mural` type to be consistent with the API with respect to optional properties.
- Maintain standard card dimensions in mural picker when the user's initials aren't available.

![image](https://user-images.githubusercontent.com/7122091/233459295-8a93c9b9-89c2-4bae-a709-ebcae538d83b.png)
