### PR TITLE
[CWI-103] Account Chooser in Outlook - Background is incorrect when the window in small

### DIFF
--- a/packages/mural-account-chooser/src/components/account-chooser/styles.ts
+++ b/packages/mural-account-chooser/src/components/account-chooser/styles.ts
@@ -12,7 +12,7 @@ export const Loading = styled.div`
 
 export const AccountChooserContainer = styled.div`
   display: flex;
-  height: 100vh;
+  min-height: 100%;
   flex-direction: column;
   align-items: center;
   color: ${({ theme }) => theme.primaryTextColor};
@@ -123,7 +123,7 @@ export const AdditionalOptionContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-top: 30px;
+  margin: 30px 0;
 `;
 
 export const AdditionalOptionText = styled.div`


### PR DESCRIPTION
Account Chooser in Outlook - Background is incorrect when the window in small

https://mural.atlassian.net/browse/CWI-103