### PR TITLE
[CWI-1996] Add attribute for setting iframe policy permissions

### DIFF
--- a/packages/mural-canvas/src/components/canvas/index.tsx
+++ b/packages/mural-canvas/src/components/canvas/index.tsx
@@ -139,10 +139,16 @@ export class CanvasHost extends React.Component<PropTypes> {
     window.removeEventListener('message', this.handleMessage);
   }
 
+  getIframePermissionsPolicy() {
+    // Assumes single level parent domain from top-level domain. Ex: a.example.com -> *.example.com
+    return `clipboard-write self *.${window.location.hostname.split('.').slice(-2).join('.')};`
+  }
+
   render() {
     const { apiClient, authUrl, canvasLink, canvasParams, onBack } = this.props;
-    if (!canvasLink)
+    if (!canvasLink) {
       throw new Error(`Cannot render the supplied 'canvasLink': ${canvasLink}`);
+    }
 
     // Add the canvasParams to the URL
     let canvasUrl = new URL(canvasLink.toString());
@@ -159,11 +165,14 @@ export class CanvasHost extends React.Component<PropTypes> {
     canvasUrl.searchParams.set('utm_source', 'mural-canvas');
     canvasUrl.searchParams.set('utm_content', apiClient.config.appId);
 
+    const iframePermissionPolicy = this.getIframePermissionsPolicy();
+
     // Convert the url to the session activation link if supported
     if (apiClient.authenticated()) {
       if (authUrl) {
         // Redirect flow
         canvasUrl = muralSessionActivationUrl(apiClient, authUrl, canvasUrl);
+
       } else if (this.props.rpcClient) {
         // RPC flow
         canvasUrl = muralSessionActivationUrlRpc(apiClient, canvasUrl);
@@ -178,6 +187,7 @@ export class CanvasHost extends React.Component<PropTypes> {
         src={canvasUrl.href}
         referrerPolicy="origin"
         seamless
+        allow={iframePermissionPolicy}
       />
     );
   }

--- a/packages/mural-canvas/src/components/canvas/index.tsx
+++ b/packages/mural-canvas/src/components/canvas/index.tsx
@@ -139,7 +139,7 @@ export class CanvasHost extends React.Component<PropTypes> {
     window.removeEventListener('message', this.handleMessage);
   }
 
-  getIframePermissionsPolicy() {
+  getIframeCrossOriginPermissionsPolicy() {
     // Assumes single level parent domain from top-level domain. Ex: a.example.com -> *.example.com
     return `clipboard-write self *.${window.location.hostname.split('.').slice(-2).join('.')};`
   }
@@ -165,7 +165,7 @@ export class CanvasHost extends React.Component<PropTypes> {
     canvasUrl.searchParams.set('utm_source', 'mural-canvas');
     canvasUrl.searchParams.set('utm_content', apiClient.config.appId);
 
-    const iframePermissionPolicy = this.getIframePermissionsPolicy();
+    const iframeCrossOriginPermissionsPolicy = this.getIframeCrossOriginPermissionsPolicy();
 
     // Convert the url to the session activation link if supported
     if (apiClient.authenticated()) {
@@ -187,7 +187,7 @@ export class CanvasHost extends React.Component<PropTypes> {
         src={canvasUrl.href}
         referrerPolicy="origin"
         seamless
-        allow={iframePermissionPolicy}
+        allow={iframeCrossOriginPermissionsPolicy}
       />
     );
   }


### PR DESCRIPTION
Add attribute for setting iframe policy permissions to allow clipboard write access for all domains sharing the same root domain as parent.

Reference: https://www.chromium.org/Home/chromium-security/deprecating-permissions-in-cross-origin-iframes/