### PR TITLE
[BOP-150] Add requestAccessToMural client method and handle NO_ACCESS_TO_MURAL event

### DIFF
--- a/packages/mural-canvas/src/components/canvas/index.tsx
+++ b/packages/mural-canvas/src/components/canvas/index.tsx
@@ -18,6 +18,7 @@ interface CanvasEvents {
   onMemberAccessDenied?: EventHandler;
   onMessage?: EventHandler<MessageEvent>;
   onMuralUnavailable?: EventHandler;
+  onNoAccessToMural?: EventHandler;
   onReady?: EventHandler;
   onVisitorAccessDenied?: EventHandler;
 }
@@ -29,6 +30,7 @@ const MESSAGE_EVENT: Record<string, keyof CanvasEvents> = {
   'mural.invalid_invitation': 'onInvalidInvitation',
   'mural.member_access_denied': 'onMemberAccessDenied',
   'mural.mural_unavailable': 'onMuralUnavailable',
+  'mural.no_access_to_mural': 'onNoAccessToMural',
   'mural.ready': 'onReady',
   'mural.visitor_access_denied': 'onVisitorAccessDenied',
 };

--- a/packages/mural-canvas/src/components/canvas/index.tsx
+++ b/packages/mural-canvas/src/components/canvas/index.tsx
@@ -18,7 +18,6 @@ interface CanvasEvents {
   onMemberAccessDenied?: EventHandler;
   onMessage?: EventHandler<MessageEvent>;
   onMuralUnavailable?: EventHandler;
-  onNoAccessToMural?: EventHandler;
   onReady?: EventHandler;
   onVisitorAccessDenied?: EventHandler;
 }
@@ -30,7 +29,6 @@ const MESSAGE_EVENT: Record<string, keyof CanvasEvents> = {
   'mural.invalid_invitation': 'onInvalidInvitation',
   'mural.member_access_denied': 'onMemberAccessDenied',
   'mural.mural_unavailable': 'onMuralUnavailable',
-  'mural.no_access_to_mural': 'onNoAccessToMural',
   'mural.ready': 'onReady',
   'mural.visitor_access_denied': 'onVisitorAccessDenied',
 };

--- a/packages/mural-client/src/index.ts
+++ b/packages/mural-client/src/index.ts
@@ -394,6 +394,8 @@ export interface ApiClient {
     Paginated & Sorted
   >;
 
+  requestAccessToMural: (query: { muralId: string }) => Promise<void>;
+
   /**
    * @deprecated Use `getCurrentUser` instead.
    */
@@ -812,6 +814,11 @@ const buildApiClient = (
         },
       );
       return await response.json();
+    },
+    requestAccessToMural: async ({ muralId }) => {
+      await fetchFn(api(`murals/${muralId}/send-request-access`), {
+        method: 'POST',
+      });
     },
     /**
      * @deprecated


### PR DESCRIPTION
Add a requestAccessToMural method and add a handler for NO_ACCESS_TO_MURAL event to help distinguish NO_ACCESS_TO_MURAL from MURAL_UNAVAILABLE.

This change is to support the work outlined in [BOP-150](https://linear.app/mural/issue/BOP-150/salesforce-embed-coca-cola-iframe-shows-uh-oh-page-instead-of-access)

Here's the demo of the feature run locally:
https://www.loom.com/share/342fe081d96f455897da2e442050b714